### PR TITLE
Add support for absolute positions from the top, dynamic available positions

### DIFF
--- a/Sources/BottomSheet/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView.swift
@@ -24,9 +24,19 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
     fileprivate let options: [BottomSheet.Options]
     fileprivate let headerContent: HContent?
     fileprivate let mainContent: MContent
-    
-    fileprivate let allCases = BottomSheetPositionEnum.allCases.sorted(by: { $0.rawValue < $1.rawValue })
-    
+
+    fileprivate let allCases = BottomSheetPositionEnum.allCases.sorted(by: {
+        if $0.rawValue < 0 && $0.rawValue < 0 {
+            return $0.rawValue < $1.rawValue
+        } else if $0.rawValue < 0 {
+            return false
+        } else if $1.rawValue < 0 {
+            return true
+        } else {
+            return $0.rawValue < $1.rawValue
+        }
+    })
+
     // Position
     fileprivate var isHiddenPosition: Bool {
         return self.bottomSheetPosition.rawValue == 0
@@ -228,11 +238,11 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
         if self.options.backgroundBlur {
             if self.options.absolutePositionValue {
                 return Double(
-                    (self.bottomSheetPosition.rawValue - self.translation) / geometry.size.height
+                    (self.positionFromBottom(geometry: geometry) - self.translation) / geometry.size.height
                 )
             } else {
                 return Double(
-                    (self.bottomSheetPosition.rawValue * geometry.size.height - self.translation) / geometry.size.height
+                    (self.positionFromBottom(geometry: geometry) * geometry.size.height - self.translation) / geometry.size.height
                 )
             }
         } else {
@@ -255,7 +265,7 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
         if self.options.absolutePositionValue {
             return min(
                 max(
-                    self.bottomSheetPosition.rawValue - self.translation,
+                    self.positionFromBottom(geometry: geometry) - self.translation,
                     0
                 ),
                 geometry.size.height * 1.05
@@ -263,7 +273,7 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
         } else {
             return min(
                 max(
-                    (geometry.size.height * self.bottomSheetPosition.rawValue) - self.translation,
+                    (geometry.size.height * self.positionFromBottom(geometry: geometry)) - self.translation,
                     0
                 ),
                 geometry.size.height * 1.05
@@ -280,13 +290,13 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
         } else if self.isBottomPosition {
             if self.options.absolutePositionValue {
                 return max(
-                    geometry.size.height - self.bottomSheetPosition.rawValue +
+                    geometry.size.height - self.positionFromBottom(geometry: geometry) +
                     self.translation + geometry.safeAreaInsets.bottom,
                     geometry.size.height * -0.05
                 )
             } else {
                 return max(
-                    geometry.size.height - (geometry.size.height * self.bottomSheetPosition.rawValue) +
+                    geometry.size.height - (geometry.size.height * self.positionFromBottom(geometry: geometry)) +
                     self.translation + geometry.safeAreaInsets.bottom,
                     geometry.size.height * -0.05
                 )
@@ -294,19 +304,31 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
         } else {
             if self.options.absolutePositionValue {
                 return max(
-                    geometry.size.height - self.bottomSheetPosition.rawValue + self.translation,
+                    geometry.size.height - self.positionFromBottom(geometry: geometry) + self.translation,
                     geometry.size.height * -0.05
                 )
             } else {
                 return max(
-                    geometry.size.height - (geometry.size.height * self.bottomSheetPosition.rawValue) +
+                    geometry.size.height - (geometry.size.height * self.positionFromBottom(geometry: geometry)) +
                     self.translation,
                     geometry.size.height * -0.05
                 )
             }
         }
     }
-    
+
+    fileprivate func positionFromBottom(geometry: GeometryProxy) -> CGFloat {
+        if options.absolutePositionValue {
+            if bottomSheetPosition.rawValue >= 0 {
+                return bottomSheetPosition.rawValue
+            } else {
+                return geometry.size.height + bottomSheetPosition.rawValue // rawValue is negative
+            }
+        } else {
+            return bottomSheetPosition.rawValue
+        }
+    }
+
     fileprivate func endEditing() {
         UIApplication.shared.endEditing()
     }

--- a/Sources/BottomSheet/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView.swift
@@ -227,15 +227,9 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
     // Functions
     fileprivate func opacityValue(geometry: GeometryProxy) -> Double {
         if self.options.backgroundBlur {
-            if self.options.absolutePositionValue {
-                return Double(
-                    (self.positionFromBottom(geometry: geometry) - self.translation) / geometry.size.height
-                )
-            } else {
-                return Double(
-                    (self.positionFromBottom(geometry: geometry) * geometry.size.height - self.translation) / geometry.size.height
-                )
-            }
+            return Double(
+                (self.positionFromBottom(geometry: geometry) - self.translation) / geometry.size.height
+            )
         } else {
             return 0
         }
@@ -253,23 +247,13 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
     }
     
     fileprivate func frameHeightValue(geometry: GeometryProxy) -> Double {
-        if self.options.absolutePositionValue {
-            return min(
-                max(
-                    self.positionFromBottom(geometry: geometry) - self.translation,
-                    0
-                ),
-                geometry.size.height * 1.05
-            )
-        } else {
-            return min(
-                max(
-                    (geometry.size.height * self.positionFromBottom(geometry: geometry)) - self.translation,
-                    0
-                ),
-                geometry.size.height * 1.05
-            )
-        }
+        return min(
+            max(
+                self.positionFromBottom(geometry: geometry) - self.translation,
+                0
+            ),
+            geometry.size.height * 1.05
+        )
     }
     
     fileprivate func offsetYValue(geometry: GeometryProxy) -> Double {
@@ -279,36 +263,21 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
                 geometry.size.height * -0.05
             )
         } else if self.isBottomPosition {
-            if self.options.absolutePositionValue {
-                return max(
-                    geometry.size.height - self.positionFromBottom(geometry: geometry) +
-                    self.translation + geometry.safeAreaInsets.bottom,
-                    geometry.size.height * -0.05
-                )
-            } else {
-                return max(
-                    geometry.size.height - (geometry.size.height * self.positionFromBottom(geometry: geometry)) +
-                    self.translation + geometry.safeAreaInsets.bottom,
-                    geometry.size.height * -0.05
-                )
-            }
+            return max(
+                geometry.size.height - self.positionFromBottom(geometry: geometry) +
+                self.translation + geometry.safeAreaInsets.bottom,
+                geometry.size.height * -0.05
+            )
         } else {
-            if self.options.absolutePositionValue {
-                return max(
-                    geometry.size.height - self.positionFromBottom(geometry: geometry) + self.translation,
-                    geometry.size.height * -0.05
-                )
-            } else {
-                return max(
-                    geometry.size.height - (geometry.size.height * self.positionFromBottom(geometry: geometry)) +
-                    self.translation,
-                    geometry.size.height * -0.05
-                )
-            }
+            return max(
+                geometry.size.height - self.positionFromBottom(geometry: geometry) + self.translation,
+                geometry.size.height * -0.05
+            )
         }
     }
 
-    /// Given the current `bottomSheetPosition` and `geometry`, what should the position of the sheet be in points from the bottom?
+    /// Given the current `self.bottomSheetPosition`, `self.options`, and `geometry`,
+    /// how many points from the bottom should the top of the sheet be?
     fileprivate func positionFromBottom(geometry: GeometryProxy) -> CGFloat {
         Self.positionFromBottom(
             height: geometry.size.height,
@@ -324,7 +293,8 @@ where BottomSheetPositionEnum.RawValue == CGFloat,
                 return height + position.rawValue // rawValue is negative
             }
         } else {
-            return position.rawValue
+            let percent = position.rawValue >= 0 ? position.rawValue : (1 + position.rawValue)
+            return height * percent
         }
     }
 

--- a/Sources/BottomSheet/Helper/ViewExtension.swift
+++ b/Sources/BottomSheet/Helper/ViewExtension.swift
@@ -14,6 +14,7 @@ public extension View {
      - Parameter bottomSheetPosition: A binding that saves the current state of the BottomSheet.
      This can be any `enum` that conforms to `CGFloat`, `CaseIterable` and `Equatable`.
      For more information about custom enums see `BottomSheetPosition`.
+     - Parameter availablePositions: Positions which may be moved to by the user.
      - Parameter options: An array that contains the settings / options for the BottomSheet.
      Can be `nil`. For more information about the possible options see `BottomSheet.Options`.
      - Parameter headerContent: A view that is used as header content for the BottomSheet.
@@ -23,6 +24,7 @@ public extension View {
     func bottomSheet<HContent: View,
                      MContent: View,
                      BottomSheetPositionEnum: RawRepresentable>(bottomSheetPosition: Binding<BottomSheetPositionEnum>,
+                                                                availablePositions: [BottomSheetPositionEnum],
                                                                 options: [BottomSheet.Options] =  [],
                                                                 @ViewBuilder headerContent: () -> HContent? = { return nil },
                                                                 @ViewBuilder mainContent: () -> MContent) -> some View
@@ -32,6 +34,7 @@ public extension View {
               ZStack {
                   self
                   BottomSheetView(bottomSheetPosition: bottomSheetPosition,
+                                  availablePositions: availablePositions,
                                   options: options,
                                   headerContent: headerContent,
                                   mainContent: mainContent)
@@ -44,6 +47,7 @@ public extension View {
      - Parameter bottomSheetPosition: A binding that saves the current state of the BottomSheet.
      This can be any `enum` that conforms to `CGFloat`, `CaseIterable` and `Equatable`.
      For more information about custom enums see `BottomSheetPosition`.
+     - Parameter availablePositions: Positions which may be moved to by the user.
      - Parameter options: An array that contains the settings / options for the BottomSheet.
      For more information about the possible options see `BottomSheet.Options`.
      - Parameter title: A string that is used as the title for the BottomSheet.
@@ -52,6 +56,7 @@ public extension View {
      */
     func bottomSheet<MContent: View,
                      BottomSheetPositionEnum: RawRepresentable>(bottomSheetPosition: Binding<BottomSheetPositionEnum>,
+                                                                availablePositions: [BottomSheetPositionEnum],
                                                                 options: [BottomSheet.Options] = [],
                                                                 title: String? = nil,
                                                                 @ViewBuilder content: () -> MContent) -> some View
@@ -61,6 +66,7 @@ public extension View {
               ZStack {
                   self
                   BottomSheetView(bottomSheetPosition: bottomSheetPosition,
+                                  availablePositions: availablePositions,
                                   options: options,
                                   title: title,
                                   content: content)


### PR DESCRIPTION
This PR makes two enhancements:

- Allow specifying absolute positions from the top of the containing view by using a negative raw value.
- Allow dynamically specifying the available positions for the sheet, via the `availablePositions` argument.

Using a method `positionFromBottom(...)` to calculate the value of the same name enabled removing a lot of redundant calculation logic.