### PR TITLE
Adjust width of sheet on rotate

### DIFF
--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -187,8 +187,24 @@ internal extension BottomSheetView {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
         } else {
-            // On iPhone or iPad split screen use 100% of the width
-            return geometry.size.width
+
+            // As a default use 100% of the width.
+            guard let window = UIApplication.shared.windows.first,
+                  let interfaceOrientation = window.windowScene?.interfaceOrientation
+            else {
+                return geometry.size.width
+            }
+
+            switch interfaceOrientation {
+            // On iPhone portrait or iPad split screen use 100% of the width.
+            case .portrait, .portraitUpsideDown:
+                return geometry.size.width
+            // On iPhone landscape use 100% of the width.
+            case .landscapeLeft, .landscapeRight:
+                return geometry.size.width // * 0.4 in main repo
+            default:
+                return geometry.size.width
+            }
         }
 #endif
     }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -94,7 +94,25 @@ internal extension BottomSheetView {
             self.configuration.isResizable && self.configuration.isDragIndicatorShown ? 20 : 0
         )
     }
-    
+
+    // Whether the BottomSheet should float on rotation
+    var shouldFloat: Bool {
+        guard let window = UIApplication.shared.windows.first,
+              let interfaceOrientation = window.windowScene?.interfaceOrientation
+        else {
+            return false
+        }
+
+        switch interfaceOrientation {
+        case .portrait, .portraitUpsideDown:
+            return false
+        case .landscapeLeft, .landscapeRight:
+            return true
+        default:
+            return false
+        }
+    }
+
     // The maximum height of the BottomSheet
     func maxBottomSheetHeight(with geometry: GeometryProxy) -> CGFloat {
         // Screen height without safe areas and padding
@@ -186,25 +204,12 @@ internal extension BottomSheetView {
         if self.isIPad {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
+        } else if shouldFloat {
+            // On iPhone landscape use 40% of the width
+            return geometry.size.width * 0.4
         } else {
-
-            // As a default use 100% of the width.
-            guard let window = UIApplication.shared.windows.first,
-                  let interfaceOrientation = window.windowScene?.interfaceOrientation
-            else {
-                return geometry.size.width
-            }
-
-            switch interfaceOrientation {
-            // On iPhone portrait or iPad split screen use 100% of the width.
-            case .portrait, .portraitUpsideDown:
-                return geometry.size.width
-            // On iPhone landscape use 100% of the width.
-            case .landscapeLeft, .landscapeRight:
-                return geometry.size.width // * 0.4 in main repo
-            default:
-                return geometry.size.width
-            }
+            // On iPhone portrait or iPad split screen use 100% of the width
+            return geometry.size.width
         }
 #endif
     }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -186,11 +186,8 @@ internal extension BottomSheetView {
         if self.isIPad {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
-        } else if UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape {
-            // On iPhone landscape use 40% of the width
-            return geometry.size.width * 0.4
         } else {
-            // On iPhone portrait or iPad split screen use 100% of the width
+            // On iPhone or iPad split screen use 100% of the width
             return geometry.size.width
         }
 #endif


### PR DESCRIPTION
This PR changes the width of the drawer when the device rotates to landscape. Previously it had been set to a smaller percentage of the screen width, but for our application the drawer frame properties should not change. 